### PR TITLE
Remove console.table() statement in 1-hbnb.js

### DIFF
--- a/web_dynamic/static/scripts/1-hbnb.js
+++ b/web_dynamic/static/scripts/1-hbnb.js
@@ -15,7 +15,5 @@ $(document).ready(function () {
     }
 
     amenitiesHeading4.text(Object.values(amenitiesDict).join(", "));
-
-    console.table(amenitiesDict);
   });
 });


### PR DESCRIPTION
This pull request removes the console.table() statement in the 1-hbnb.js file. The statement was no longer needed and has been removed to improve code cleanliness.